### PR TITLE
Fix incorrect Firestore field names

### DIFF
--- a/src/model/education.ts
+++ b/src/model/education.ts
@@ -27,8 +27,8 @@ export const educationConverter = {
         return {
             id: education.id,
             school: education.school,
-            position: education.degree,
-            company: education.fieldOfStudy,
+            degree: education.degree,
+            fieldOfStudy: education.fieldOfStudy,
             startDate: education.startDate,
             endDate: education.endDate,
             description: education.description


### PR DESCRIPTION
## Summary
- correct property names written to Firestore for `Education`

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459bd83f248320ac8b5efbf90020f8