### PR TITLE
Fix array types in models

### DIFF
--- a/src/model/award.ts
+++ b/src/model/award.ts
@@ -5,10 +5,10 @@ export class Award {
     id: string;
     title: string;
     issuer: string;
-    description: [string];
+    description: string[];
     date: Timestamp;
 
-    constructor(id: string, title: string, issuer: string, date: Timestamp, description: [string]) {
+    constructor(id: string, title: string, issuer: string, date: Timestamp, description: string[]) {
         this.id = id;
         this.title = title;
         this.issuer = issuer;

--- a/src/model/education.ts
+++ b/src/model/education.ts
@@ -6,11 +6,11 @@ export class Education {
     school: string;
     degree: string;
     fieldOfStudy: string;
-    description: [string];
+    description: string[];
     startDate: Timestamp;
     endDate: Timestamp;
 
-    constructor(id: string, school: string, degree: string, fieldOfStudy: string, startDate: Timestamp, endDate: Timestamp, description: [string]) {
+    constructor(id: string, school: string, degree: string, fieldOfStudy: string, startDate: Timestamp, endDate: Timestamp, description: string[]) {
         this.id = id;
         this.school = school;
         this.degree = degree;

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -6,8 +6,8 @@ export class Project {
     name: string;
     description: string;
     platform: string;
-    techStack: [string];
-    media: [string];
+    techStack: string[];
+    media: string[];
     github: string;
     link: string;
     // category: DocumentReference;
@@ -17,8 +17,8 @@ export class Project {
         name: string,
         description: string,
         platform: string,
-        techStack: [string],
-        media: [string],
+        techStack: string[],
+        media: string[],
         github: string,
         link: string,
         // category: DocumentReference

--- a/src/model/volunteer.ts
+++ b/src/model/volunteer.ts
@@ -5,11 +5,11 @@ export class Volunteer {
     id: string;
     organisation: string;
     position: string;
-    description: [string];
+    description: string[];
     startDate: Timestamp;
     endDate: Timestamp;
 
-    constructor(id: string, organisation: string, position: string, startDate: Timestamp, endDate: Timestamp, description: [string]) {
+    constructor(id: string, organisation: string, position: string, startDate: Timestamp, endDate: Timestamp, description: string[]) {
         this.id = id;
         this.organisation = organisation;
         this.position = position;


### PR DESCRIPTION
## Summary
- convert `[string]` tuple types to standard `string[]` arrays in Award, Education, Volunteer, and Project models

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459d22c04483209a1322b4c1673026